### PR TITLE
Skip dotfiles when organizing files based on creation date

### DIFF
--- a/classifier/classifier.py
+++ b/classifier/classifier.py
@@ -47,7 +47,7 @@ def classify_by_date(date_format, output_dir):
     print("Scanning Files")
 
     directory = os.getcwd()
-    files = os.listdir(directory)
+    files = [x for x in os.listdir(directory) if not x.startswith('.')]
     creation_dates = map(lambda x: (x, arrow.get(os.path.getctime(x))), files)
 
     for file, creation_date in creation_dates:


### PR DESCRIPTION
Running command "classifier" in something like Dropbox, Syncthing or your $HOME
folder and using '-dt' option also moves invisible dotfiles. Should it?

Might be issue for some files like:

 - .dropbox
 - .DS_Store
 - .gitignore
 - .htaccess
 - .picasa.ini
 - ... and more

For me, created issue with Syncthing - after .stfolder file was moved, it
stopped syncing the folder:

	tanel@~/Downloads/test$ tree -a
	.
	├── .stfolder
	├── image1.jpg
	├── text1.txt
	└── text2.txt
	tanel@~/Downloads/test$ classifier -dt
	Scanning Files
	Done!
	tanel@~/Downloads/test$ tree -a
	.
	└── 02-02-2016
	    ├── .stfolder
	    ├── image1.jpg
	    ├── text1.txt
	    └── text2.txt

	1 directory, 4 files

Please ignore if it's not a big issue ;)