### PR TITLE
Update requirement for six >= 1.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         """,
         install_requires=[
             'arrow',
-            'six',
+            'six>=1.10.0',
         ],
         zip_safe=False
 )


### PR DESCRIPTION
As mentioned in #45 , it is necessary to specify **six >= 1.10.0** in requirement.