### PR TITLE
add category "Programs", fixes #54

### DIFF
--- a/classifier/classifier.py
+++ b/classifier/classifier.py
@@ -102,6 +102,7 @@ def main():
                               '.ppt', '.pptx', '.ppsx', '.odp', '.odt', '.ods', '.md', '.json', '.csv'],
         'Books': ['.mobi', '.epub', '.chm'],
         'DEBPackages': ['.deb'],
+        'Programs': ['.exe', '.msi'],
         'RPMPackages': ['.rpm']
     }
 


### PR DESCRIPTION
`Programs` is the standard name used by many applications for the Windows-executable category.
Fixes #54 