### PR TITLE
Support for custom configuration

### DIFF
--- a/classifier/classifier.py
+++ b/classifier/classifier.py
@@ -7,6 +7,8 @@ import sys
 
 from six.moves import getcwd
 
+from . import config
+
 """
 All format lists were taken from wikipedia, not all of them were added due to extensions
 not being exclusive to one format such as webm, or raw
@@ -93,17 +95,8 @@ def main():
 
     args = parser.parse_args()
 
-    formats = {
-        'Music'	: ['.mp3', '.aac', '.flac', '.ogg', '.wma', '.m4a', '.aiff', '.wav'],
-        'Videos': ['.flv', '.ogv', '.avi', '.mp4', '.mpg', '.mpeg', '.3gp', '.mkv', '.ts'],
-        'Pictures': ['.png', '.jpeg', '.gif', '.jpg', '.bmp', '.svg', '.webp', '.psd'],
-        'Archives': ['.rar', '.zip', '.7z', '.gz', '.bz2', '.tar', '.dmg', '.tgz', '.xz'],
-        'Documents': ['.txt', '.pdf', '.doc', '.docx', '.xls', '.xlsv', '.xlsx',
-                              '.ppt', '.pptx', '.ppsx', '.odp', '.odt', '.ods', '.md', '.json', '.csv'],
-        'Books': ['.mobi', '.epub', '.chm'],
-        'DEBPackages': ['.deb'],
-        'RPMPackages': ['.rpm']
-    }
+    config.init_config(write_file=True)
+    formats = config.get_formats()
 
     if bool(args.specific_folder) ^ bool(args.specific_types):
         print(

--- a/classifier/config.py
+++ b/classifier/config.py
@@ -1,0 +1,96 @@
+"""Configure for classifier
+"""
+
+import os
+
+import six.moves.configparser as configparser
+
+CONFIG_PATH = os.path.expanduser('~/.classifier.cfg')
+CONFIG = None
+
+ELEMENT_DILIMETER = ','
+KEY_VAL_DILIMETER = ':'
+
+FORMATS = 'Formats'
+DEFAULT_CONFIG = {
+    FORMATS: {
+        'Music': ['.mp3', '.aac', '.flac', '.ogg', '.wma', '.m4a', '.aiff', '.wav'],
+        'Videos': ['.flv', '.ogv', '.avi', '.mp4', '.mpg', '.mpeg', '.3gp', '.mkv', '.ts'],
+        'Pictures': ['.png', '.jpeg', '.gif', '.jpg', '.bmp', '.svg', '.webp', '.psd'],
+        'Archives': ['.rar', '.zip', '.7z', '.gz', '.bz2', '.tar', '.dmg', '.tgz', '.xz'],
+        'Documents': ['.txt', '.pdf', '.doc', '.docx', '.xls', '.xlsv', '.xlsx',
+                      '.ppt', '.pptx', '.ppsx', '.odp', '.odt', '.ods', '.md', '.json', '.csv'],
+        'Books': ['.mobi', '.epub', '.chm'],
+        'DEBPackages': ['.deb'],
+        'RPMPackages': ['.rpm']
+    }
+}
+
+
+def _pair_string(pair):
+    return "%s%s %s" % (pair[0].strip(), KEY_VAL_DILIMETER, pair[1].strip())
+
+
+def _string_pair(s):
+    k, v = s.split(KEY_VAL_DILIMETER)
+    return k.strip(), v.strip()
+
+
+def _set(parser, section, items):
+    try:
+        parser.add_section(section)
+    except configparser.DuplicateSectionError:
+        pass
+    dilimeter = "%s " % ELEMENT_DILIMETER
+    for key, val in items.items():
+        if type(val) is list:
+            val_str = dilimeter.join(list(map(lambda s: s.strip(), val)))
+            parser.set(section, key, val_str)
+        elif type(val) is dict:
+            val_str = dilimeter.join(list(map(_pair_string, val.items())))
+            parser.set(section, key, val_str)
+        else:
+            parser.set(section, key, val)
+
+
+def _init_config(parser, config):
+    for sec, values in config.items():
+        _set(parser, sec, values)
+
+
+def init_config(write_file=False):
+    global CONFIG
+    if CONFIG is None:
+        CONFIG = configparser.SafeConfigParser()
+
+    if os.path.exists(CONFIG_PATH):
+        try:
+            CONFIG.read(CONFIG_PATH)
+        except configparser.ParsingError:
+            _init_config(CONFIG, DEFAULT_CONFIG)
+    else:
+        _init_config(CONFIG, DEFAULT_CONFIG)
+        if write_file:
+            with open(CONFIG_PATH, 'w') as config_file:
+                CONFIG.write(config_file)
+
+
+def _get(parser, section, typ=None):
+    conf = {}
+    for key, val in parser.items(section):
+        if typ is list:
+            conf[key] = list(map(lambda s: s.strip(),
+                                 val.split(ELEMENT_DILIMETER)))
+        elif typ is dict:
+            conf[key] = dict(_string_pair(e)
+                             for e in val.split(ELEMENT_DILIMETER))
+        else:
+            conf[key] = val.strip()
+    return conf
+
+
+def get_formats():
+    try:
+        return _get(CONFIG, FORMATS, typ=list)
+    except configparser.NoSectionError:
+        return DEFAULT_CONFIG[FORMATS]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import six.moves.configparser as configparser
+
+from classifier import config
+
+
+class ConfigTest(unittest.TestCase):
+
+    def test_config(self):
+        raw = {'a': '123'}
+        dicts = {'a': {'aa': 'bb', 'b': 'bb'}}
+        lists = {'a': ['x', 'y', 'z']}
+        conf = configparser.SafeConfigParser()
+        config._set(conf, 'raw', raw)
+        config._set(conf, 'dicts', dicts)
+        config._set(conf, 'lists', lists)
+        assert config._get(conf, 'raw') == raw
+        assert config._get(conf, 'dicts', dict) == dicts
+        assert config._get(conf, 'lists', list) == lists
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Support for configuring in `$HOME/.classifier.cfg`.
If the file exists, try to parse from it, else use the default config and save it to the file.
If parse error OR formats not configured properly, also use the default(**Not save**).