### PR TITLE
fix platform for win32 and python2 in linux

### DIFF
--- a/classifier/classifier.py
+++ b/classifier/classifier.py
@@ -20,12 +20,16 @@ import sys
 VERSION = 'Classifier 1.99dev'
 DIRCONFFILE = '.classifier.conf'
 PLATFORM = sys.platform
+OS = os.name
+
 if PLATFORM == 'darwin':
     CONFIG = os.path.join(os.path.expanduser('~'), '.classifier-master.conf')
-elif PLATFORM == 'nt':
+elif PLATFORM == 'win32' or OS == 'nt':
     CONFIG = os.path.join(os.getenv('userprofile'), 'classifier-master.conf')
-elif PLATFORM == 'linux':
+elif PLATFORM == 'linux' or PLATFORM == 'linux2' or OS == 'posix':
     CONFIG = os.path.join(os.getenv('HOME'), '.classifier-master.conf')
+else:
+    CONFIG = os.path.join(os.getcwd(), '.classifier-master.conf')
 
 
 def main():
@@ -168,6 +172,7 @@ class Classifier:
         return
 
     def _format_text_arg(self, arg):
+        """ Set a date format to name your folders"""
         if not isinstance(arg, str):
             arg = arg.decode('utf-8')
         return arg
@@ -190,9 +195,9 @@ class Classifier:
         if self.args.edittypes:
             if PLATFORM == 'darwin':
                 subprocess.call(('open', CONFIG))
-            elif PLATFORM == 'nt':
+            elif PLATFORM == 'win32' or OS == 'nt':
                 os.startfile(CONFIG)
-            elif PLATFORM == 'linux':
+            elif PLATFORM == 'linux' or PLATFORM == 'linux2' or OS == 'posix'
                 subprocess.Popen(['xdg-open', CONFIG])
             return False
         if bool(self.args.specific_folder) ^ bool(self.args.specific_types):

--- a/classifier/classifier.py
+++ b/classifier/classifier.py
@@ -197,7 +197,7 @@ class Classifier:
                 subprocess.call(('open', CONFIG))
             elif PLATFORM == 'win32' or OS == 'nt':
                 os.startfile(CONFIG)
-            elif PLATFORM == 'linux' or PLATFORM == 'linux2' or OS == 'posix'
+            elif PLATFORM == 'linux' or PLATFORM == 'linux2' or OS == 'posix':
                 subprocess.Popen(['xdg-open', CONFIG])
             return False
         if bool(self.args.specific_folder) ^ bool(self.args.specific_types):


### PR DESCRIPTION
Platform is inconsistent between python2 and 3 on linux. (linux and linux2)
Platform on win32 v2/3 is consistent but was using os.name (nt instead of win32)

I have access to osx and windows using python2 and 3 now so i will be able to test more thoroughly.
I did all my testing in python 3 so i will make sure i do both now to avoid creating this issue again.

I will also not work on anything else until i can test all new features in test_classifier.py